### PR TITLE
Avoid refitting the mosaic on resize when it is hidden

### DIFF
--- a/jquery.mosaic.js
+++ b/jquery.mosaic.js
@@ -41,6 +41,9 @@
 
 			if (o.refitOnResize)
 				$(window).on('resize', null, null, function() {
+				  if (base.$el.is(':hidden')) {
+						return;
+				  }
 					if (o.refitOnResizeDelay) {
 						if (refitTimeout)
 							clearTimeout(refitTimeout);
@@ -52,6 +55,10 @@
 						base.fit()
 				});
 		}
+
+		base.$el.on('jqMosaicRefit', function() {
+			base.fit();
+		});
 
 		base.getItems = function() {
 			return $('> div:not([data-no-mosaic=true]), > a:not([data-no-mosaic=true]), > img:not([data-no-mosaic=true])', base.el);


### PR DESCRIPTION
Refitting hidden mosaic is pointless and it does not work anyway (the
images end up with 0×0 dimensions).  When the gallery is revealed and the
viewport size has changed while it was hidden, your code must invoke a
'jqMosaicRefit' event on the main div (DIV.mosaic), otherwise it will no
longer be correctly fit to it.  This could possibly be made automatic
with MutationObserver, but for the time being, this should suffice.