### PR TITLE
One more thing needed for VIDEO elements to work properly

### DIFF
--- a/jquery.mosaic.css
+++ b/jquery.mosaic.css
@@ -14,7 +14,8 @@
 
 .jQueryMosaic > div,
 .jQueryMosaic > a,
-.jQueryMosaic > img {
+.jQueryMosaic > img,
+.jQueryMosaic > video {
 	float: left;
 }
 

--- a/jquery.mosaic.js
+++ b/jquery.mosaic.js
@@ -41,6 +41,9 @@
 
 			if (o.refitOnResize)
 				$(window).on('resize', null, null, function() {
+				  if (base.$el.is(':hidden')) {
+						return;
+				  }
 					if (o.refitOnResizeDelay) {
 						if (refitTimeout)
 							clearTimeout(refitTimeout);
@@ -52,6 +55,10 @@
 						base.fit()
 				});
 		}
+
+		base.$el.on('jqMosaicRefit', function() {
+			base.fit();
+		});
 
 		base.getItems = function() {
 			return $('> div:not([data-no-mosaic=true]), > a:not([data-no-mosaic=true]), > img:not([data-no-mosaic=true])', base.el);


### PR DESCRIPTION
Hello again from me. I am very sorry, but I forgot to update the CSS to `float : left` the VIDEO elements too. Without it they will always end up on the right side no matter where in the row they are. I had this in my original update, but when creating the pull request I forgot to include this.